### PR TITLE
Write response of export_installation in chunks

### DIFF
--- a/lib/ops_manager_ui_drivers/version14/api_1_4.rb
+++ b/lib/ops_manager_ui_drivers/version14/api_1_4.rb
@@ -10,12 +10,14 @@ module OpsManagerUiDrivers
       end
 
       def export_installation
-        response = http.request(get('installation_asset_collection'))
-
-        Tempfile.new('installation.zip').tap do |tempfile|
-          tempfile.write(response.body)
-          tempfile.close
+        tmpfile = Tempfile.new('installation.zip')
+        http.request(get('installation_asset_collection')) do |response|
+          response.read_body do |chunk|
+            tmpfile.write(chunk)
+          end
         end
+        tmpfile.close
+        tmpfile
       end
 
       private


### PR DESCRIPTION
- We ran out of memory running the export in a docker container on GoCD.
  This should write the response in chunks as it arrives.

Signed-off-by: Dave Liebreich dliebreich@pivotal.io
