### PR TITLE
Add expectation after assign networks vsphere

### DIFF
--- a/lib/ops_manager_ui_drivers/version14/ops_manager_director.rb
+++ b/lib/ops_manager_ui_drivers/version14/ops_manager_director.rb
@@ -174,7 +174,7 @@ module OpsManagerUiDrivers
           browser.select deployment_network
         end
         browser.click_on 'Save'
-        browser.has_text?('Successfully assigned infrastructure network')
+        browser.wait { browser.has_text?('Successfully assigned infrastructure network') }
       end
 
       def assign_network(deployment_network:)

--- a/lib/ops_manager_ui_drivers/version14/ops_manager_director.rb
+++ b/lib/ops_manager_ui_drivers/version14/ops_manager_director.rb
@@ -174,6 +174,7 @@ module OpsManagerUiDrivers
           browser.select deployment_network
         end
         browser.click_on 'Save'
+        browser.has_text?('Successfully assigned infrastructure network')
       end
 
       def assign_network(deployment_network:)

--- a/lib/ops_manager_ui_drivers/version15/ops_manager_director.rb
+++ b/lib/ops_manager_ui_drivers/version15/ops_manager_director.rb
@@ -154,7 +154,7 @@ module OpsManagerUiDrivers
           browser.select deployment_network
         end
         browser.click_on 'Save'
-        browser.has_text?('Successfully assigned infrastructure network')
+        browser.wait { browser.has_text?('Successfully assigned infrastructure network') }
       end
 
       def assign_network(deployment_network:)

--- a/lib/ops_manager_ui_drivers/version15/ops_manager_director.rb
+++ b/lib/ops_manager_ui_drivers/version15/ops_manager_director.rb
@@ -154,6 +154,7 @@ module OpsManagerUiDrivers
           browser.select deployment_network
         end
         browser.click_on 'Save'
+        browser.has_text?('Successfully assigned infrastructure network')
       end
 
       def assign_network(deployment_network:)


### PR DESCRIPTION
- Configuring the director was failing to assign networks in vsphere; it seems
  that the driver was not waiting long enough for the network to be assigned in
  vsphere.

Signed-off-by: Morgan Fine mfine@pivotal.io
