### PR TITLE
Change revert methods to public

### DIFF
--- a/lib/ops_manager_ui_drivers/version13/product_dashboard.rb
+++ b/lib/ops_manager_ui_drivers/version13/product_dashboard.rb
@@ -84,6 +84,17 @@ module OpsManagerUiDrivers
         delete_whole_installation if delete_installation_available?
       end
 
+      def revert_pending_changes
+        open_dashboard
+        browser.click_on 'open-revert-installation-modal-action'
+        wait_for_modal_css_transition_to_complete
+        browser.click_on 'revert-installation-action'
+      end
+
+      def revert_available?
+        browser.all('#open-revert-installation-modal-action').any?
+      end
+
       private
 
       attr_reader :browser
@@ -140,17 +151,6 @@ module OpsManagerUiDrivers
 
       def open_dashboard
         browser.visit '/'
-      end
-
-      def revert_pending_changes
-        open_dashboard
-        browser.click_on 'open-revert-installation-modal-action'
-        wait_for_modal_css_transition_to_complete
-        browser.click_on 'revert-installation-action'
-      end
-
-      def revert_available?
-        browser.all('#open-revert-installation-modal-action').any?
       end
     end
   end

--- a/lib/ops_manager_ui_drivers/version14/product_dashboard.rb
+++ b/lib/ops_manager_ui_drivers/version14/product_dashboard.rb
@@ -98,6 +98,17 @@ module OpsManagerUiDrivers
         end
       end
 
+      def revert_pending_changes
+        open_dashboard
+        browser.click_on 'open-revert-installation-modal-action'
+        wait_for_modal_css_transition_to_complete
+        browser.click_on 'revert-installation-action'
+      end
+
+      def revert_available?
+        browser.all('#open-revert-installation-modal-action').any?
+      end
+
       private
 
       attr_reader :browser
@@ -158,17 +169,6 @@ module OpsManagerUiDrivers
 
       def open_dashboard
         browser.visit '/'
-      end
-
-      def revert_pending_changes
-        open_dashboard
-        browser.click_on 'open-revert-installation-modal-action'
-        wait_for_modal_css_transition_to_complete
-        browser.click_on 'revert-installation-action'
-      end
-
-      def revert_available?
-        browser.all('#open-revert-installation-modal-action').any?
       end
     end
   end

--- a/lib/ops_manager_ui_drivers/version15/product_dashboard.rb
+++ b/lib/ops_manager_ui_drivers/version15/product_dashboard.rb
@@ -100,6 +100,18 @@ module OpsManagerUiDrivers
         end
       end
 
+      def revert_pending_changes
+        open_dashboard
+        browser.click_on 'open-revert-installation-modal-action'
+        wait_for_modal_css_transition_to_complete
+        browser.click_on 'revert-installation-action'
+      end
+
+      def revert_available?
+        open_dashboard
+        browser.all('#open-revert-installation-modal-action').any?
+      end
+
       private
 
       attr_reader :browser
@@ -160,17 +172,6 @@ module OpsManagerUiDrivers
 
       def open_dashboard
         browser.visit '/'
-      end
-
-      def revert_pending_changes
-        open_dashboard
-        browser.click_on 'open-revert-installation-modal-action'
-        wait_for_modal_css_transition_to_complete
-        browser.click_on 'revert-installation-action'
-      end
-
-      def revert_available?
-        browser.all('#open-revert-installation-modal-action').any?
       end
     end
   end


### PR DESCRIPTION
- This makes reverting product changes part of the public API. This is
  useful because the configure microbosh ui helper is not idempotent. It
  attempts to add the AZ even if it is already configured. Now, a user can
  revert the changes before configuring.

[#93856588]

Signed-off-by: Dave Liebreich dliebreich@pivotal.io
