### PR TITLE
Setting allow url is deprecated

### DIFF
--- a/lib/ops_manager_ui_drivers/page_helpers.rb
+++ b/lib/ops_manager_ui_drivers/page_helpers.rb
@@ -28,7 +28,6 @@ module OpsManagerUiDrivers
 
     def create_web_ui(ops_manager_url, version_module)
       Capybara.app_host = ops_manager_url
-      page.driver.allow_url(Capybara.app_host)
       puts "Preparing to interact with #{version_module.inspect} at #{Capybara.app_host}"
       version_module::WebUi.new(browser: self)
     end


### PR DESCRIPTION
- Should use Capybara::Webkit.configure. This will require a change to
  all consumers of the ops_manager_ui_drivers gem. See this PR for an
  example: https://github.com/pivotal-cf/opsmgr/pull/2

[#98834088]

Signed-off-by: Difan Zhao dzhao@pivotal.io
