### PR TITLE
Product added - use find instead of all

### DIFF
--- a/lib/ops_manager_ui_drivers/version13/available_products.rb
+++ b/lib/ops_manager_ui_drivers/version13/available_products.rb
@@ -12,7 +12,12 @@ module OpsManagerUiDrivers
 
       def product_added?(product_name)
         browser.visit '/'
-        browser.all("#show-#{product_name}-configure-action").any?
+
+        begin
+          !browser.find("#show-#{product_name}-configure-action").nil?
+        rescue Capybara::ElementNotFound
+          false
+        end
       end
 
       private

--- a/lib/ops_manager_ui_drivers/version14/available_products.rb
+++ b/lib/ops_manager_ui_drivers/version14/available_products.rb
@@ -12,7 +12,12 @@ module OpsManagerUiDrivers
 
       def product_added?(product_name)
         browser.visit '/'
-        browser.all("#show-#{product_name}-configure-action").any?
+
+        begin
+          !browser.find("#show-#{product_name}-configure-action").nil?
+        rescue Capybara::ElementNotFound
+          false
+        end
       end
 
       private

--- a/lib/ops_manager_ui_drivers/version15/available_products.rb
+++ b/lib/ops_manager_ui_drivers/version15/available_products.rb
@@ -12,7 +12,12 @@ module OpsManagerUiDrivers
 
       def product_added?(product_name)
         browser.visit '/'
-        browser.all("#show-#{product_name}-configure-action").any?
+
+        begin
+          !browser.find("#show-#{product_name}-configure-action").nil?
+        rescue Capybara::ElementNotFound
+          false
+        end
       end
 
       private


### PR DESCRIPTION
- This allows Capybara to wait default_max_wait_time for the product
  tile to appear instead of failing immediately.

[#99105418]

Signed-off-by: Morgan Fine mfine@pivotal.io
