### PR TITLE
Product add - use find to ensure it has been added

### DIFF
--- a/lib/ops_manager_ui_drivers/version13/available_products.rb
+++ b/lib/ops_manager_ui_drivers/version13/available_products.rb
@@ -8,6 +8,7 @@ module OpsManagerUiDrivers
       def add_product_to_install(product_name)
         browser.visit '/'
         browser.click_on "add-#{product_name}"
+        browser.find("#show-#{product_name}-configure-action")
       end
 
       def product_added?(product_name)

--- a/lib/ops_manager_ui_drivers/version14/available_products.rb
+++ b/lib/ops_manager_ui_drivers/version14/available_products.rb
@@ -8,6 +8,7 @@ module OpsManagerUiDrivers
       def add_product_to_install(product_name)
         browser.visit '/'
         browser.click_on "add-#{product_name}"
+        browser.find("#show-#{product_name}-configure-action")
       end
 
       def product_added?(product_name)

--- a/lib/ops_manager_ui_drivers/version15/available_products.rb
+++ b/lib/ops_manager_ui_drivers/version15/available_products.rb
@@ -8,6 +8,7 @@ module OpsManagerUiDrivers
       def add_product_to_install(product_name)
         browser.visit '/'
         browser.click_on "add-#{product_name}"
+        browser.find("#show-#{product_name}-configure-action")
       end
 
       def product_added?(product_name)


### PR DESCRIPTION
- This allows Capybara to wait default_max_wait_time for the product
  tile to appear

[#99105418]

Signed-off-by: Morgan Fine mfine@pivotal.io
