### PR TITLE
Configure experimental features for versions 1.5 and 1.6

### DIFF
--- a/lib/ops_manager_ui_drivers/version15/ops_manager_director.rb
+++ b/lib/ops_manager_ui_drivers/version15/ops_manager_director.rb
@@ -20,6 +20,8 @@ module OpsManagerUiDrivers
         assign_networks(test_settings.ops_manager)
 
         customize_resource_config(test_settings.ops_manager.resource_config)
+
+        configure_experimental_features(test_settings.ops_manager.experimental_features)
       end
 
       def configure_iaas(test_settings)
@@ -165,6 +167,14 @@ module OpsManagerUiDrivers
         end
         browser.click_on 'Save'
         browser.poll_up_to_times(20) { browser.assert_text('Settings updated') }
+      end
+
+      def configure_experimental_features(experimental_features)
+        browser.click_on 'Experimental Features'
+
+        trusted_certificates = experimental_features ? experimental_features.trusted_certificates : ''
+
+        browser.fill_in('experimental_features[trusted_certificates]', with: trusted_certificates)
       end
 
       private

--- a/lib/ops_manager_ui_drivers/version16/ops_manager_director.rb
+++ b/lib/ops_manager_ui_drivers/version16/ops_manager_director.rb
@@ -20,6 +20,8 @@ module OpsManagerUiDrivers
         assign_networks(test_settings.ops_manager)
 
         customize_resource_config(test_settings.ops_manager.resource_config)
+
+        configure_experimental_features(test_settings.ops_manager.experimental_features)
       end
 
       def configure_iaas(test_settings)
@@ -162,6 +164,14 @@ module OpsManagerUiDrivers
         end
         browser.click_on 'Save'
         browser.poll_up_to_times(20) { browser.assert_text('Settings updated') }
+      end
+
+      def configure_experimental_features(experimental_features)
+        browser.click_on 'Experimental Features'
+
+        trusted_certificates = experimental_features ? experimental_features.trusted_certificates : ''
+
+        browser.fill_in('experimental_features[trusted_certificates]', with: trusted_certificates)
       end
 
       private

--- a/spec/ops_manager_ui_drivers/version15/ops_manager_director_spec.rb
+++ b/spec/ops_manager_ui_drivers/version15/ops_manager_director_spec.rb
@@ -450,6 +450,42 @@ module OpsManagerUiDrivers
           end
         end
       end
+
+      describe '#configure_experimental_features' do
+        context 'when trusted certs are present in the experimental features configuration' do
+          let(:test_settings_hash) do
+            {
+              'ops_manager' => {
+                'experimental_features' => {
+                  'trusted_certificates' => 'NO REALLY, I AM A CERTIFICATE THAT IS TOTALLY VALID',
+                }
+              }
+            }
+          end
+
+          it 'adds the certs to the `Trusted Certificates` area' do
+            ops_manager_director.configure_experimental_features(test_settings.ops_manager.experimental_features)
+
+            expect(browser).to have_received(:click_on).with('Experimental Features')
+            expect(browser).to have_received(:fill_in).with('experimental_features[trusted_certificates]', with: 'NO REALLY, I AM A CERTIFICATE THAT IS TOTALLY VALID')
+          end
+        end
+
+        context 'when experimental features are not configured' do
+          let(:test_settings_hash) do
+            {
+              'ops_manager' => {}
+            }
+          end
+
+          it 'makes sure that the `Trusted Certificates` area is empty' do
+            ops_manager_director.configure_experimental_features(test_settings.ops_manager.experimental_features)
+
+            expect(browser).to have_received(:click_on).with('Experimental Features')
+            expect(browser).to have_received(:fill_in).with('experimental_features[trusted_certificates]', with: '')
+          end
+        end
+      end
     end
   end
 end

--- a/spec/ops_manager_ui_drivers/version16/ops_manager_director_spec.rb
+++ b/spec/ops_manager_ui_drivers/version16/ops_manager_director_spec.rb
@@ -450,6 +450,42 @@ module OpsManagerUiDrivers
           end
         end
       end
+
+      describe '#configure_experimental_features' do
+        context 'when trusted certs are present in the experimental features configuration' do
+          let(:test_settings_hash) do
+            {
+              'ops_manager' => {
+                'experimental_features' => {
+                  'trusted_certificates' => 'NO REALLY, I AM A CERTIFICATE THAT IS TOTALLY VALID',
+                }
+              }
+            }
+          end
+
+          it 'adds the certs to the `Trusted Certificates` area' do
+            ops_manager_director.configure_experimental_features(test_settings.ops_manager.experimental_features)
+
+            expect(browser).to have_received(:click_on).with('Experimental Features')
+            expect(browser).to have_received(:fill_in).with('experimental_features[trusted_certificates]', with: 'NO REALLY, I AM A CERTIFICATE THAT IS TOTALLY VALID')
+          end
+        end
+
+        context 'when experimental features are not configured' do
+          let(:test_settings_hash) do
+            {
+              'ops_manager' => {}
+            }
+          end
+
+          it 'makes sure that the `Trusted Certificates` area is empty' do
+            ops_manager_director.configure_experimental_features(test_settings.ops_manager.experimental_features)
+
+            expect(browser).to have_received(:click_on).with('Experimental Features')
+            expect(browser).to have_received(:fill_in).with('experimental_features[trusted_certificates]', with: '')
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
- Allows setting `Trusted Certificates` field

Required for GemFire for PCF team's upgrade specs - old version of the tile can't have the Trusted Certificates present, but new version won't work without them.
