### PR TITLE
Save the form after configuring the Trusted Certificates

### DIFF
--- a/lib/ops_manager_ui_drivers/version15/ops_manager_director.rb
+++ b/lib/ops_manager_ui_drivers/version15/ops_manager_director.rb
@@ -176,6 +176,7 @@ module OpsManagerUiDrivers
         trusted_certificates = experimental_features ? experimental_features.trusted_certificates : ''
 
         browser.fill_in('experimental_features[trusted_certificates]', with: trusted_certificates)
+        browser.click_on 'Save'
       end
 
       private

--- a/lib/ops_manager_ui_drivers/version16/ops_manager_director.rb
+++ b/lib/ops_manager_ui_drivers/version16/ops_manager_director.rb
@@ -173,6 +173,7 @@ module OpsManagerUiDrivers
         trusted_certificates = experimental_features ? experimental_features.trusted_certificates : ''
 
         browser.fill_in('experimental_features[trusted_certificates]', with: trusted_certificates)
+        browser.click_on 'Save'
       end
 
       private

--- a/spec/ops_manager_ui_drivers/version15/ops_manager_director_spec.rb
+++ b/spec/ops_manager_ui_drivers/version15/ops_manager_director_spec.rb
@@ -468,6 +468,7 @@ module OpsManagerUiDrivers
 
             expect(browser).to have_received(:click_on).with('Experimental Features')
             expect(browser).to have_received(:fill_in).with('experimental_features[trusted_certificates]', with: 'NO REALLY, I AM A CERTIFICATE THAT IS TOTALLY VALID')
+            expect(browser).to have_received(:click_on).with('Save')
           end
         end
 
@@ -483,6 +484,7 @@ module OpsManagerUiDrivers
 
             expect(browser).to have_received(:click_on).with('Experimental Features')
             expect(browser).to have_received(:fill_in).with('experimental_features[trusted_certificates]', with: '')
+            expect(browser).to have_received(:click_on).with('Save')
           end
         end
       end

--- a/spec/ops_manager_ui_drivers/version16/ops_manager_director_spec.rb
+++ b/spec/ops_manager_ui_drivers/version16/ops_manager_director_spec.rb
@@ -468,6 +468,7 @@ module OpsManagerUiDrivers
 
             expect(browser).to have_received(:click_on).with('Experimental Features')
             expect(browser).to have_received(:fill_in).with('experimental_features[trusted_certificates]', with: 'NO REALLY, I AM A CERTIFICATE THAT IS TOTALLY VALID')
+            expect(browser).to have_received(:click_on).with('Save')
           end
         end
 
@@ -483,6 +484,7 @@ module OpsManagerUiDrivers
 
             expect(browser).to have_received(:click_on).with('Experimental Features')
             expect(browser).to have_received(:fill_in).with('experimental_features[trusted_certificates]', with: '')
+            expect(browser).to have_received(:click_on).with('Save')
           end
         end
       end


### PR DESCRIPTION
Actually save the form after entering the Trusted Certificates.
