### PR TITLE
Explicitly labels Availability Zone drop down menu

### DIFF
--- a/lib/ops_manager_ui_drivers/version17/ops_manager_director.rb
+++ b/lib/ops_manager_ui_drivers/version17/ops_manager_director.rb
@@ -103,7 +103,7 @@ module OpsManagerUiDrivers
           when OpsManagerUiDrivers::VSPHERE_IAAS_TYPE
             browser.click_on 'Assign AZs and Networks'
             browser.select(ops_manager.dig('networks', 0, 'name'), from: 'Network')
-            browser.select(iaas_availability_zones.first['name'])
+            browser.select(iaas_availability_zones.first['name'], from: 'Singleton Availability Zone')
           when OpsManagerUiDrivers::VCLOUD_IAAS_TYPE
             browser.click_on 'Assign Networks'
             browser.select(ops_manager.dig('networks', 0, 'name'), from: 'Network')


### PR DESCRIPTION
Signed-off-by: Brenda Chan brchan@pivotal.io

We ran into an issue deploying 1.7 Ops Manager when our availability zone and network both shared the same name "default".  

This fix explicitly labels the drop down menus on the "Assign AZ and Networks" tab to allow this.

```
1) Configuring director configures director
     Failure/Error: current_ops_manager.ops_manager_director.configure_bosh_product(env_settings)

     Capybara::Ambiguous:
       Ambiguous match, found 2 elements matching option "default"
```
