### PR TITLE
Allow to select an option on product page

### DIFF
--- a/lib/ops_manager_ui_drivers/version17/product_form.rb
+++ b/lib/ops_manager_ui_drivers/version17/product_form.rb
@@ -23,6 +23,11 @@ module OpsManagerUiDrivers
         browser.find_field(name)
       end
 
+      def select_option(property_reference:, option_value:)
+        name = "#{form_name}" + property_reference.map {|field| "[#{field}]" }.join
+        browser.find_field(name).find(:option, option_value).select_option
+      end
+
       def generate_self_signed_cert(wildcard_domain, property_reference, selector_property_reference = nil, selector_option_name = nil)
         if selector_property_reference && selector_option_name
           private_key_field_name = "#{form_name}[#{selector_property_reference}][#{selector_option_name}][#{property_reference}][private_key_pem]"
@@ -75,10 +80,11 @@ module OpsManagerUiDrivers
         end
       end
 
-      def open_form
+      def open_form(form = nil)
+        form = form || "show-#{form_name}-action"
         browser.visit '/'
         browser.click_on "show-#{product_name}-configure-action"
-        browser.click_on "show-#{form_name}-action"
+        browser.click_on form
       end
 
       private

--- a/spec/ops_manager_ui_drivers/version17/product_form_spec.rb
+++ b/spec/ops_manager_ui_drivers/version17/product_form_spec.rb
@@ -21,6 +21,34 @@ module OpsManagerUiDrivers
         end
       end
 
+      describe '#select_option' do
+        let(:product_form) {
+          OpsManagerUiDrivers::Version17::ProductForm.new(
+            browser:      browser,
+            product_name: 'product_name',
+            form_name:    'form_name',
+          )
+        }
+        let(:browser) { double('browser') }
+        let(:select) { double('select') }
+        let(:options) { double('options') }
+        let(:option) { double('option') }
+
+        it 'finds and select the specified option' do
+          expect(browser).to receive(:find_field)
+            .with('form_name[select_name][select_field]')
+            .and_return(options)
+          expect(options).to receive(:find)
+            .with(:option, 5)
+            .and_return(option)
+          expect(option).to receive(:select_option)
+          product_form.select_option(
+            property_reference: ['select_name', 'select_field'],
+            option_value: 5
+          )
+        end
+      end
+
       describe '#fill_in_selector_property' do
         let(:product_form) {
           OpsManagerUiDrivers::Version17::ProductForm.new(


### PR DESCRIPTION
We want to change the resource configuration on the product page.

We had to change the open_form as the resource configuration has a different name pattern.

Signed-off-by: Alex Blease ablease@pivotal.io
