### PR TITLE
Use uniq availiability zones

### DIFF
--- a/lib/ops_manager_ui_drivers/version17/ops_manager_director.rb
+++ b/lib/ops_manager_ui_drivers/version17/ops_manager_director.rb
@@ -36,11 +36,11 @@ module OpsManagerUiDrivers
         case iaas_type
           when OpsManagerUiDrivers::AWS_IAAS_TYPE, OpsManagerUiDrivers::OPENSTACK_IAAS_TYPE, OpsManagerUiDrivers::GOOGLE_IAAS_TYPE
             return unless iaas_availability_zones
-            iaas_availability_zones && iaas_availability_zones.each do |az|
+            iaas_availability_zones && iaas_availability_zones.uniq.each do |az|
               availability_zones.add_az('iaas_identifier' => az['iaas_identifier'])
             end
           when OpsManagerUiDrivers::VSPHERE_IAAS_TYPE
-            iaas_availability_zones && iaas_availability_zones.each do |az|
+            iaas_availability_zones && iaas_availability_zones.uniq.each do |az|
               availability_zones.add_az('name' => az['name'], 'cluster' => az['cluster'], 'resource_pool' => az['resource_pool'])
             end
         end


### PR DESCRIPTION
Sometimes cloudformation creates subnets in the same availability
zone. We need to pass all zones ids to the configure script.
Unfortunately, it is possible to create AZs with the same name, so we
have to filter this case in the code.

[#126501111]

Signed-off-by: Oleksandr Slynko oslynko@pivotal.io
